### PR TITLE
moved whois to dcim

### DIFF
--- a/observer/cmd/autobot/autobot.go
+++ b/observer/cmd/autobot/autobot.go
@@ -23,9 +23,9 @@ func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "telegram IM bot")
 	token := app.Flag("telegram.token", "Telegram token.").Required().OverrideDefaultFromEnvar("TELEGRAM_TOKEN").String()
 	listServerUri := app.Flag("list.manager.uri", "URI of the server keeping lists.").Default("http://localhost:9190").OverrideDefaultFromEnvar("LIST_MANAGER_URI").String()
+	whoisServerUri := app.Flag("whois.uri", "URI of the whois server.").Default("http://localhost:38000").OverrideDefaultFromEnvar("WHOIS_URI").String()
 	banGroup := app.Flag("ban.group", "Name of banned list , managed by IM bot.").Default("ban").OverrideDefaultFromEnvar("BAN_GROUP").String()
 	notifyGroup := app.Flag("notify.group", "Name of notification list, managed by IM bot.").Default("notify").OverrideDefaultFromEnvar("NOTIFY_GROUP").String()
-	whoisFileName := app.Flag("whois.file", "Path to file with whois database.").Default("/var/spool/whois.txt").OverrideDefaultFromEnvar("WHOIS_FILE").String()
 
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -33,7 +33,7 @@ func main() {
 	var carrier im.Carrier = telegram.New(*token)
 
 	chuck.Register(carrier)
-	whois.Register(carrier, *whoisFileName)
+	whois.Register(carrier, *whoisServerUri)
 	listmgmt.Register(carrier, *listServerUri, *banGroup)
 	listmgmt.Register(carrier, *listServerUri, *notifyGroup)
 

--- a/observer/cmd/dcim/dcim.go
+++ b/observer/cmd/dcim/dcim.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"syscall"
 
 	"github.com/gorilla/mux"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -21,26 +24,38 @@ func main() {
 	portNum := app.Flag("port", "Port number to listen.").Default(":38000").OverrideDefaultFromEnvar("DCIM_PORT").String()
 	path := app.Flag("db", "DCIM DB file.").Default("/var/spool/dcim-db.json").OverrideDefaultFromEnvar("DCIM_DB").String()
 	whoisFileName := app.Flag("whois.file", "Path to file with whois database.").Default("/var/spool/whois.txt").OverrideDefaultFromEnvar("WHOIS_FILE").String()
+	whoisUpdateTimer := app.Flag("whois.timer", "Update timer.").Default("30m").OverrideDefaultFromEnvar("WHOIS_UPDATE_TIMER").Duration()
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	// init components
 	var repository dcim.Storing = dcim.NewRepoInMemory(*path)
-	var service dcim.DeviceService = dcim.NewDeviceService(repository)
-	var whois dcim.WhoisService = dcim.NewWhoisService(*whoisFileName)
+	var service *dcim.DeviceService = dcim.NewDeviceService(repository)
+	var whois *dcim.WhoisService = dcim.NewWhoisService(*whoisFileName, *whoisUpdateTimer)
 
 	if err := repository.Initialize(); err != nil {
 		log.Fatal("main:: ", err)
 	}
-	whois.Run()
 
 	// setup handlers
 	router := mux.NewRouter()
-	service.SetHandlers(router)
-	whois.SetHandlers(router)
+	dcim.SetHandlers(router, service, whois)
 
 	// run http server
-	if err := http.ListenAndServe(*portNum, router); err != nil {
-		log.Fatal(err)
+	go func() {
+		if err := http.ListenAndServe(*portNum, router); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	// gracefull shutdown
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	select {
+	case <-ctx.Done():
+		log.Println("Services stops by IPC signal")
+		// TODO: implement service graceful shutdown
+		// device-service, whois-service
+
+		stop()
 	}
 }

--- a/observer/cmd/dcim/dcim.go
+++ b/observer/cmd/dcim/dcim.go
@@ -20,20 +20,26 @@ func main() {
 	app := kingpin.New(filepath.Base(os.Args[0]), "DCIM")
 	portNum := app.Flag("port", "Port number to listen.").Default(":38000").OverrideDefaultFromEnvar("DCIM_PORT").String()
 	path := app.Flag("db", "DCIM DB file.").Default("/var/spool/dcim-db.json").OverrideDefaultFromEnvar("DCIM_DB").String()
+	whoisFileName := app.Flag("whois.file", "Path to file with whois database.").Default("/var/spool/whois.txt").OverrideDefaultFromEnvar("WHOIS_FILE").String()
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	// init components
 	var repository dcim.Storing = dcim.NewRepoInMemory(*path)
 	var service dcim.DeviceService = dcim.NewDeviceService(repository)
+	var whois dcim.WhoisService = dcim.NewWhoisService()
 
 	if err := repository.Initialize(); err != nil {
 		log.Fatal("main:: ", err)
+	}
+	if err := whois.Load(*whoisFileName); err != nil {
+		log.Fatal("main::", err)
 	}
 
 	// setup handlers
 	router := mux.NewRouter()
 	service.SetHandlers(router)
+	whois.SetHandlers(router)
 
 	// run http server
 	if err := http.ListenAndServe(*portNum, router); err != nil {

--- a/observer/cmd/dcim/dcim.go
+++ b/observer/cmd/dcim/dcim.go
@@ -27,14 +27,12 @@ func main() {
 	// init components
 	var repository dcim.Storing = dcim.NewRepoInMemory(*path)
 	var service dcim.DeviceService = dcim.NewDeviceService(repository)
-	var whois dcim.WhoisService = dcim.NewWhoisService()
+	var whois dcim.WhoisService = dcim.NewWhoisService(*whoisFileName)
 
 	if err := repository.Initialize(); err != nil {
 		log.Fatal("main:: ", err)
 	}
-	if err := whois.Load(*whoisFileName); err != nil {
-		log.Fatal("main::", err)
-	}
+	whois.Run()
 
 	// setup handlers
 	router := mux.NewRouter()

--- a/observer/dcim/webapi.go
+++ b/observer/dcim/webapi.go
@@ -1,14 +1,22 @@
 package dcim
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"regexp"
 
+	"fort.plus/fperror"
 	"github.com/gorilla/mux"
 )
 
 const (
-	BASE_URI = "/api/v1/"
+	BASE_URI  = "/api/v1/"
+	WHOIS_URI = "/api/v1/whois"
 )
 
 type DeviceService struct {
@@ -72,4 +80,77 @@ func (s *DeviceService) CheckDNSName() error {
 
 func (s *DeviceService) CheckIsAlive() error {
 	return nil
+}
+
+// WhoisService represent whois information endpoint
+type WhoisService struct {
+	data []byte
+}
+
+func NewWhoisService() WhoisService {
+	return WhoisService{}
+}
+
+func (wh *WhoisService) Load(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		err = fperror.Warning("can't open file", err)
+		log.Println(err)
+		return err
+	}
+	defer file.Close()
+
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		err = fperror.Warning("can't read all bytes", err)
+		return err
+	}
+	wh.data = bytes
+	return nil
+}
+
+func (wh *WhoisService) match(pattern string) []string {
+	var result []string
+	re := regexp.MustCompile(pattern)
+	scanner := bufio.NewScanner(bytes.NewReader(wh.data))
+	scanner.Split(bufio.ScanLines)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if re.Match([]byte(line)) {
+			result = append(result, line)
+		}
+	}
+	return result
+}
+
+func (wh *WhoisService) SetHandlers(r *mux.Router) {
+	r.HandleFunc(WHOIS_URI, wh.Get).Methods(http.MethodGet)
+}
+
+func (wh *WhoisService) Get(w http.ResponseWriter, r *http.Request) {
+	// parse query
+	var q struct {
+		Query string `json:"query"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
+		log.Println("WhoisService::Get failed parse json request:", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	defer r.Body.Close()
+
+	// grep result
+	result := wh.match(q.Query)
+
+	// write result
+	raw, err := json.Marshal(result)
+	if err != nil {
+		log.Println("WhoisService::get failed marshal response")
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Header().Add("Content-Type", "application/json; charset=utf-8")
+	w.Write(raw)
 }

--- a/observer/dcim/webapi.go
+++ b/observer/dcim/webapi.go
@@ -21,6 +21,10 @@ const (
 	WHOIS_URI = "/api/v1/whois"
 )
 
+var (
+	whoisUpdateTimer = time.Minute * 30
+)
+
 type DeviceService struct {
 	storage Storing
 }
@@ -112,7 +116,7 @@ func (wh *WhoisService) update() {
 		select {
 		case <-wh.resetHoldTimer:
 			log.Println("WhoisService::update reset hold timer")
-		case <-time.After(time.Second * 5):
+		case <-time.After(whoisUpdateTimer):
 			log.Println("WhoisService::update file on timer")
 			if err := wh.load(); err != nil {
 				log.Println("WhoisService::update failed Load data-file", err)

--- a/observer/dcim/webapi_test.go
+++ b/observer/dcim/webapi_test.go
@@ -17,19 +17,18 @@ func TestWhoisService(t *testing.T) {
 	path := "/home/ag/whois.txt"
 
 	t.Run("bad file-path", func(t *testing.T) {
-		whois := NewWhoisService("/bad/path/to-file")
-		whois.Run()
+		whois := NewWhoisService("/bad/path/to-file", time.Duration(time.Minute))
+		// whois.Run()
+		fmt.Println(whois)
 	})
 
 	t.Run("load text-file", func(t *testing.T) {
-		whois := NewWhoisService(path)
-		whois.Run()
+		whois := NewWhoisService(path, time.Duration(time.Minute))
 		log.Println(len(whois.data))
 	})
 
 	t.Run("math #1", func(t *testing.T) {
-		whois := NewWhoisService(path)
-		whois.Run()
+		whois := NewWhoisService(path, time.Duration(time.Minute))
 		result := whois.match("10.1.1.1")
 		for _, line := range result {
 			fmt.Println(line)
@@ -41,8 +40,7 @@ func TestWhoisService(t *testing.T) {
 	})
 
 	t.Run("test handler", func(t *testing.T) {
-		whois := NewWhoisService(path)
-		whois.Run()
+		whois := NewWhoisService(path, time.Duration(time.Minute))
 		q := struct {
 			Query string `json:"query"`
 		}{
@@ -59,8 +57,7 @@ func TestWhoisService(t *testing.T) {
 	})
 
 	t.Run("update goroutine", func(t *testing.T) {
-		whois := NewWhoisService(path)
-		whois.Run()
+		whois := NewWhoisService(path, time.Duration(time.Minute))
 
 		time.Sleep(time.Second * 6)
 		whois.resetHoldTimer <- true

--- a/observer/dcim/webapi_test.go
+++ b/observer/dcim/webapi_test.go
@@ -1,0 +1,67 @@
+package dcim
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWhoisService(t *testing.T) {
+
+	path := "/var/spool/whois.txt"
+
+	t.Run("bad file-path", func(t *testing.T) {
+		whois := NewWhoisService()
+		if err := whois.Load("/bad/path/to-file"); err == nil {
+			t.Fatal(err)
+		}
+		t.Log("test fails as expected")
+	})
+
+	t.Run("load text-file", func(t *testing.T) {
+		whois := NewWhoisService()
+		if err := whois.Load(path); err != nil {
+			t.Fatal(err)
+		}
+		log.Println(len(whois.data))
+	})
+
+	t.Run("math #1", func(t *testing.T) {
+		whois := NewWhoisService()
+		if err := whois.Load(path); err != nil {
+			t.Fatal(err)
+		}
+		result := whois.match("10.64.16.12")
+		for _, line := range result {
+			fmt.Println(line)
+		}
+		result = whois.match("Vlan1200")
+		for _, line := range result {
+			fmt.Println(line)
+		}
+	})
+
+	t.Run("test handler", func(t *testing.T) {
+		whois := NewWhoisService()
+		if err := whois.Load(path); err != nil {
+			t.Fatal(err)
+		}
+		q := struct {
+			Query string `json:"query"`
+		}{
+			Query: ".*Vlan1200",
+		}
+		rawQuery, _ := json.Marshal(q)
+
+		resp := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/whois", bytes.NewBuffer(rawQuery))
+		whois.Get(resp, req)
+
+		fmt.Println("response code:", resp.Code)
+		fmt.Println("response body:", resp.Body)
+	})
+}

--- a/observer/dcim/webapi_test.go
+++ b/observer/dcim/webapi_test.go
@@ -35,11 +35,11 @@ func TestWhoisService(t *testing.T) {
 		if err := whois.Load(path); err != nil {
 			t.Fatal(err)
 		}
-		result := whois.match("10.64.16.12")
+		result := whois.match("10.1.1.1")
 		for _, line := range result {
 			fmt.Println(line)
 		}
-		result = whois.match("Vlan1200")
+		result = whois.match("Vlan111")
 		for _, line := range result {
 			fmt.Println(line)
 		}
@@ -53,7 +53,7 @@ func TestWhoisService(t *testing.T) {
 		q := struct {
 			Query string `json:"query"`
 		}{
-			Query: ".*Vlan1200",
+			Query: ".*Vlan111",
 		}
 		rawQuery, _ := json.Marshal(q)
 

--- a/observer/extension/autobot/whois/whois.go
+++ b/observer/extension/autobot/whois/whois.go
@@ -14,10 +14,6 @@ import (
 	httpTransport "fort.plus/transport"
 )
 
-var (
-	carrier im.Carrier
-)
-
 type query struct {
 	Query string `json:"query"`
 }
@@ -39,35 +35,45 @@ func (b *dcimBotClient) get(message repository.RegExComparator) {
 	msg := im.Cast(message)
 	re := regexp.MustCompile("/whois (.*)")
 	match := re.FindStringSubmatch(msg.Text)
-
-	// build query
 	q := query{match[0]}
+	response := b.fromService(q)
+	b.carrier.Send(msg.From, response)
+}
 
-	// send request to service
+// fromService send http-request to whois-service and parse response
+func (b *dcimBotClient) fromService(q query) string {
+	// masrhal request to json-bytes
 	raw, err := json.Marshal(q)
 	if err != nil {
-		b.carrier.Send(msg.From, fmt.Sprintf("can' marshal JSON query, %s", err))
-		return
+		return fmt.Sprintf("can' marshal JSON query, %s", err)
 	}
 
+	// send request to service
 	resp, err := httpTransport.Request(http.MethodGet, b.serverUri+"/api/v1/whois", bytes.NewBuffer(raw))
 	if err != nil {
-		b.carrier.Send(msg.From, fmt.Sprintf("failed then request dcim/whois service, %s", err))
-		return
+		return fmt.Sprintf("failed then request dcim/whois service, %s", err)
+	}
+
+	if resp.StatusCode == http.StatusNoContent {
+		return fmt.Sprintf("get status code: 204 (no content) from whois-service for query:%v", q.Query)
+	}
+	if resp.StatusCode == http.StatusBadRequest {
+		return fmt.Sprintf("get status code: 404 (bad request) from whois-service for query:%v", q.Query)
+	}
+	if resp.StatusCode == http.StatusInternalServerError {
+		return fmt.Sprintf("get status code: 500 from whois-service for query:%v", q.Query)
 	}
 
 	// parse response
 	rawResponse, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		b.carrier.Send(msg.From, fmt.Sprintf("failed then read bytes from dcim/whois service response, %s", err))
-		return
+		return fmt.Sprintf("failed then read bytes from dcim/whois service response, %s", err)
 	}
 
 	var response []string
 	if err := json.Unmarshal(rawResponse, &response); err != nil {
-		b.carrier.Send(msg.From, fmt.Sprintf("failed then parse JSON from dcim/whois service response, %s", err))
-		return
+		return fmt.Sprintf("failed then parse JSON from dcim/whois service response, %s", err)
 	}
 
-	b.carrier.Send(msg.From, strings.Join(response, "\n"))
+	return strings.Join(response, "\n")
 }

--- a/observer/extension/autobot/whois/whois.go
+++ b/observer/extension/autobot/whois/whois.go
@@ -33,15 +33,11 @@ func Register(carrier im.Carrier, serverUri string) {
 
 func (b *dcimBotClient) get(message repository.RegExComparator) {
 	msg := im.Cast(message)
-
-	// recover MustCompile possible panic
-	defer func() {
-		if r := recover(); r != nil {
-			b.carrier.Send(msg.From, fmt.Sprintf("bad search-query: %v", msg.Text))
-		}
-	}()
-
-	re := regexp.MustCompile("/whois (.*)")
+	re, err := regexp.Compile("/whois (.*)")
+	if err != nil {
+		b.carrier.Send(msg.From, fmt.Sprintf("bad search-query: %v", msg.Text))
+		return
+	}
 	match := re.FindStringSubmatch(msg.Text)
 	q := query{match[0]}
 	response := b.search(q)

--- a/observer/extension/autobot/whois/whois_test.go
+++ b/observer/extension/autobot/whois/whois_test.go
@@ -4,6 +4,6 @@ import (
 	"testing"
 )
 
-//TODO: add some tests
-func TestFindPattern(t *testing.T) {
+func TestClient(t *testing.T) {
+
 }

--- a/observer/extension/autobot/whois/whois_test.go
+++ b/observer/extension/autobot/whois/whois_test.go
@@ -1,9 +1,16 @@
 ﻿package whois
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestClient(t *testing.T) {
-
+	client := &dcimBotClient{
+		serverUri: "http://localhost:38000",
+	}
+	fmt.Println(client)
+	q := query{Query: "999"}
+	response := client.fromService(q)
+	fmt.Println(response)
 }

--- a/observer/extension/autobot/whois/whois_test.go
+++ b/observer/extension/autobot/whois/whois_test.go
@@ -11,6 +11,6 @@ func TestClient(t *testing.T) {
 	}
 	fmt.Println(client)
 	q := query{Query: "999"}
-	response := client.fromService(q)
+	response := client.search(q)
 	fmt.Println(response)
 }


### PR DESCRIPTION
Переместил whois в dcim. Теперь whois это сервис, с HTTP endpoint **_/api/v1/whois_**.
Принимает json вида 
`{"query":"some query string"}`

Отдает массив строк
`[ {"result1"}, {"result2"},...]`

В **observer/extension/autobot/whois** остался HTTP клиент.
