### PR TITLE
implementes listmanager serialize/deserialize

### DIFF
--- a/observer/cmd/listmanager/listmanager.go
+++ b/observer/cmd/listmanager/listmanager.go
@@ -20,7 +20,8 @@ func main() {
 	app.HelpFlag.Short('h')
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
+	listManager := webapi.NewListManager()
 	router := mux.NewRouter()
-	webapi.SetHandlers(router)
+	listManager.SetHandlers(router)
 	http.ListenAndServe(*portNum, router)
 }

--- a/observer/listmanager/listmanager_test.go
+++ b/observer/listmanager/listmanager_test.go
@@ -1,11 +1,10 @@
-package listmanager_test
+package listmanager
 
 import (
 	"hash/crc32"
 	"testing"
 	"time"
-
-	. "fort.plus/listmanager"
+	// . "fort.plus/listmanager"
 )
 
 var records = New("ban1")
@@ -80,6 +79,14 @@ func TestGetPatterns(t *testing.T) {
 func TestCleanExpired(t *testing.T) {
 
 	t.Run("test new timer", func(t *testing.T) {
-		time.Sleep(time.Minute * 5)
+		records.Clear()
+		records.AddRecord(Item{Pattern: "pattern1", ExpiredAt: time.Now()})
+		records.AddRecord(Item{Pattern: "pattern2", ExpiredAt: time.Now().Add(time.Second * 5)})
+		time.Sleep(time.Second * 10)
+
+		if len(records.items) > 0 {
+			t.Fatalf("expected len of items %v got %v", 0, len(records.items))
+		}
+
 	})
 }

--- a/observer/listmanager/listmanager_test.go
+++ b/observer/listmanager/listmanager_test.go
@@ -76,3 +76,10 @@ func TestGetPatterns(t *testing.T) {
 		t.Errorf("Unexpected number of patterns, expected 2 got %d", len(patterns))
 	}
 }
+
+func TestCleanExpired(t *testing.T) {
+
+	t.Run("test new timer", func(t *testing.T) {
+		time.Sleep(time.Minute * 5)
+	})
+}

--- a/observer/listmanager/webapi/webapi_test.go
+++ b/observer/listmanager/webapi/webapi_test.go
@@ -1,0 +1,51 @@
+package webapi
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	banlist "fort.plus/listmanager"
+)
+
+func TestSerialize(t *testing.T) {
+
+	lm := NewListManager()
+	fmt.Println(lm)
+
+	lm.Storage["list1"] = banlist.New("list1")
+	list1 := lm.Storage["list1"]
+	list1.AddRecord(banlist.Item{Pattern: "pattern1", ExpiredAt: time.Now().Add(time.Minute * 2)})
+	list1.AddRecord(banlist.Item{Pattern: "pattern2", ExpiredAt: time.Now().Add(time.Minute * 3)})
+
+	list2 := banlist.New("list2")
+	lm.Storage["list2"] = list2
+	list2.AddRecord(banlist.Item{Pattern: "pattern1", ExpiredAt: time.Now().Add(time.Minute * 4)})
+	list2.AddRecord(banlist.Item{Pattern: "pattern2", ExpiredAt: time.Now().Add(time.Minute * 5)})
+
+	t.Run("Serialze", func(t *testing.T) {
+
+		data, err := lm.Serialize()
+		fmt.Println(err)
+		fmt.Println(string(data))
+	})
+
+	t.Run("Deserialize", func(t *testing.T) {
+		data, err := lm.Serialize()
+		if err != nil {
+			t.Fatal(err)
+		}
+		fmt.Println("\n\n---Unmarshal")
+		lm2, err := Deserialize(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// json.Unmarshal(data, &lm2)
+		fmt.Println(lm2)
+
+		for _, value := range lm2.Storage {
+			// value.GetPatterns()
+			fmt.Println("pattern", value.GetPatterns())
+		}
+	})
+}

--- a/observer/listmanager/webapi/webapi_test.go
+++ b/observer/listmanager/webapi/webapi_test.go
@@ -1,12 +1,48 @@
 package webapi
 
 import (
+	"bytes"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	banlist "fort.plus/listmanager"
+	"github.com/gorilla/mux"
 )
+
+func TestAddRecord(t *testing.T) {
+
+	var data []byte = []byte("{\"pattern\":\"test\", \"expired_at\":\"2022-02-24T16:15:02.296629921+03:00\"}")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/list1/", bytes.NewBuffer(data))
+	w := httptest.NewRecorder()
+
+	lm := NewListManager()
+	lm.SetHandlers(mux.NewRouter())
+	lm.addRecord(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatal("bad status code", w.Code)
+	}
+	fmt.Println(lm.Storage)
+	for k, v := range lm.Storage {
+		fmt.Println(k, v)
+	}
+}
+
+func TestGetList(t *testing.T) {
+	lm := NewListManager()
+	lm.SetHandlers(mux.NewRouter())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/list1/", nil)
+	w := httptest.NewRecorder()
+	lm.getList(w, req)
+
+	data, _ := ioutil.ReadAll(w.Body)
+	fmt.Println(string(data))
+}
 
 func TestSerialize(t *testing.T) {
 
@@ -48,4 +84,12 @@ func TestSerialize(t *testing.T) {
 			fmt.Println("pattern", value.GetPatterns())
 		}
 	})
+}
+
+func TestTime(t *testing.T) {
+	t1 := time.Now()
+	tBefore := t1.Add(time.Hour * -1)
+	tAfter := t1.Add(time.Hour + 1)
+	fmt.Println(t1.After(tBefore))
+	fmt.Println(t1.Before(tAfter))
 }


### PR DESCRIPTION
Реализовал сериализацию/десериализацию listManager`a. Пришлось использовать промежуточную структуру для хранения **_ListRecords_** по нескольким причинам:
1) Поле items приватное.
2) **_map_** сериализуется сложнее чем **_slice_**.

ListManager сериализуется в такой JSON
`
{
    "storage": {
        "list1": {
            "Items": [
                {
                    "pattern": "pattern1",
                    "expired_at": "2022-02-24T16:15:02.296629921+03:00"
                },
                {
                    "pattern": "pattern2",
                    "expired_at": "2022-02-24T16:16:02.29677354+03:00"
                }
            ],
            "name": "list1"
        },
        "list2": {
            "Items": [
                {
                    "pattern": "pattern1",
                    "expired_at": "2022-02-24T16:17:02.296790634+03:00"
                },
                {
                    "pattern": "pattern2",
                    "expired_at": "2022-02-24T16:18:02.296792201+03:00"
                }
            ],
            "name": "list2"
        }
    }
}
`